### PR TITLE
Add test for Localization.getCountryCode and Localization.getLanguageCode

### DIFF
--- a/extractor/src/test/java/org/schabi/newpipe/extractor/NewPipeTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/NewPipeTest.java
@@ -1,6 +1,8 @@
 package org.schabi.newpipe.extractor;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.schabi.newpipe.extractor.localization.Localization;
 
 import java.util.HashSet;
 
@@ -24,6 +26,21 @@ public class NewPipeTest {
                             + " (current service > " + streamingService.getServiceInfo().getName() + ")";
 
             assertTrue(servicesId.add(streamingService.getServiceId()), errorMsg);
+        }
+    }
+
+    @Test
+    public void testGetCountryCodeAndGetLanguageCode() {
+        try {
+            HashSet<Integer> servicesId = new HashSet<>();
+            for (StreamingService streamingService : NewPipe.getServices()) {
+                Localization Localization1 = new Localization("W4JN-$nw<}7EGpwmm(EQ", "ndBdj-qEHp!#I]LDWP=,");
+                String errorMsg = ((("There are services with the same id = " + streamingService.getServiceId()) + " (current service > ") + streamingService.getServiceInfo().getName()) + ")";
+                streamingService.getTimeAgoParser(new Localization("W4JN-$nw<}7EGpwmm(EQ", "ndBdj-qEHp!#I]LDWP=,"));
+            }
+            Assertions.fail("testAllServicesHaveDifferentId_mg38 should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            Assertions.assertEquals("Localization is not supported (\"Localization[W4JN-$nw<}7EGpwmm(EQ-ndBdj-qEHp!#I]LDWP=,]\")", expected.getMessage());
         }
     }
 


### PR DESCRIPTION
- [ ] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Hey 😊
I want to contribute the following test:

Test that a `java.lang.IllegalArgumentException` is thrown when `getTimeAgoParser` is called with the parameter `localization = new org.schabi.newpipe.extractor.localization.Localization("W4JN-$nw<}7EGpwmm(EQ", "ndBdj-qEHp!#I]LDWP=,")`.
This tests the methods [`Localization.getCountryCode`](https://github.com/TeamNewPipe/NewPipeExtractor/blob/23fa31a1ec572cfb45f0f2fe88cc3844b151aa73/extractor/src/main/java/org/schabi/newpipe/extractor/localization/Localization.java#L71) and [`Localization.getLanguageCode`](https://github.com/TeamNewPipe/NewPipeExtractor/blob/23fa31a1ec572cfb45f0f2fe88cc3844b151aa73/extractor/src/main/java/org/schabi/newpipe/extractor/localization/Localization.java#L66).
This test is based on the test [`testAllServicesHaveDifferentId`](https://github.com/TeamNewPipe/NewPipeExtractor/blob/23fa31a1ec572cfb45f0f2fe88cc3844b151aa73/extractor/src/test/java/org/schabi/newpipe/extractor/NewPipeTest.java#L19).

Curious to hear what you think!